### PR TITLE
Convergent encryption support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ dist: trusty
 sudo: false
 
 env:
-  - VAULT_VERSION=0.6.0
-  - VAULT_VERSION=0.5.3
-  - VAULT_VERSION=0.4.1
-  - VAULT_VERSION=0.3.1
+  - VAULT_VERSION=0.10.4
+  - VAULT_VERSION=0.9.6
+  - VAULT_VERSION=0.8.3
+  - VAULT_VERSION=0.7.3
 
 gemfile:
   - Gemfile

--- a/gemfiles/rails_4.1.gemfile.lock
+++ b/gemfiles/rails_4.1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     vault-rails (0.4.0)
       rails (>= 4.1, < 5.1)
-      vault (~> 0.5)
+      vault (~> 0.7)
 
 GEM
   remote: https://rubygems.org/
@@ -39,6 +39,7 @@ GEM
       rake
       thor (>= 0.14.0)
     arel (5.0.1.20140414130214)
+    aws-sigv4 (1.0.3)
     builder (3.2.3)
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
@@ -105,7 +106,8 @@ GEM
       polyglot (>= 0.3.1)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
-    vault (0.10.1)
+    vault (0.12.0)
+      aws-sigv4
 
 PLATFORMS
   ruby
@@ -121,4 +123,4 @@ DEPENDENCIES
   vault-rails!
 
 BUNDLED WITH
-   1.15.3
+   1.16.2

--- a/gemfiles/rails_4.2.gemfile.lock
+++ b/gemfiles/rails_4.2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     vault-rails (0.4.0)
       rails (>= 4.1, < 5.1)
-      vault (~> 0.5)
+      vault (~> 0.7)
 
 GEM
   remote: https://rubygems.org/
@@ -48,6 +48,7 @@ GEM
       rake
       thor (>= 0.14.0)
     arel (6.0.3)
+    aws-sigv4 (1.0.3)
     builder (3.2.3)
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
@@ -129,7 +130,8 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
-    vault (0.10.1)
+    vault (0.12.0)
+      aws-sigv4
 
 PLATFORMS
   ruby
@@ -145,4 +147,4 @@ DEPENDENCIES
   vault-rails!
 
 BUNDLED WITH
-   1.15.3
+   1.16.2

--- a/lib/vault/rails/configurable.rb
+++ b/lib/vault/rails/configurable.rb
@@ -119,6 +119,23 @@ module Vault
       def retry_max_wait=(val)
         @retry_max_wait = val
       end
+
+      # Gets the convergent encryption context for deriving
+      # an enctyption key when using convergent encryption
+      # Raises an exception when convergent option is set
+      # to true and context is not privided
+      def convergent_encryption_context
+        unless @convergent_encryption_context
+          raise StandardError, 'Missinng configuration oprion convergent_encryption_context!'
+        end
+
+        @convergent_encryption_context
+      end
+
+      # Sets the convergent encryption context for use with convergent encryption
+      def convergent_encryption_context=(context)
+        @convergent_encryption_context = context
+      end
     end
   end
 end

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -21,5 +21,7 @@ class Person < ActiveRecord::Base
     decode: ->(raw) { raw && raw[3...-3] }
 
   vault_attribute :non_ascii
+
+  vault_attribute :email, convergent: true
 end
 

--- a/spec/dummy/db/migrate/20180816090008_add_email_encrypted_to_people.rb
+++ b/spec/dummy/db/migrate/20180816090008_add_email_encrypted_to_people.rb
@@ -1,0 +1,5 @@
+class AddEmailEncryptedToPeople < ActiveRecord::Migration[5.0]
+  def change
+    add_column :people, :email_encrypted, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150428220101) do
+ActiveRecord::Schema.define(version: 20180816090008) do
 
   create_table "people", force: :cascade do |t|
     t.string   "name"
@@ -23,6 +22,7 @@ ActiveRecord::Schema.define(version: 20150428220101) do
     t.string   "non_ascii_encrypted"
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
+    t.string   "email_encrypted"
   end
 
 end

--- a/spec/unit/rails_spec.rb
+++ b/spec/unit/rails_spec.rb
@@ -13,11 +13,93 @@ describe Vault::Rails do
     end
 
     it 'raises an exception when there is no serializer for the key' do
-      expect {
+      expect do
         Vault::Rails.serializer_for(:not_a_serializer)
-      }.to raise_error(Vault::Rails::Serializers::UnknownSerializerError) { |e|
+      end.to raise_error(Vault::Rails::Serializers::UnknownSerializerError) { |e|
         expect(e.message).to match('Unknown Vault serializer `:not_a_serializer`')
       }
+    end
+  end
+
+  describe '.encrypt' do
+    context 'when convergent encryption is enabled' do
+      before do
+        allow(Vault::Rails).to receive(:enabled?).and_return(true)
+        allow(Vault::Rails).to receive(:convergent_encryption_context).and_return('a' * 16)
+      end
+
+      it 'sends the correct paramaters to vault client' do
+        expected_route = 'path/encrypt/key'
+        expected_options = {
+          plaintext: Base64.strict_encode64('plaintext'),
+          context: Base64.strict_encode64(Vault::Rails.convergent_encryption_context),
+          convergent_encryption: true,
+          derived: true
+        }
+
+        expect(Vault::Rails.client.logical).to receive(:write)
+          .with(expected_route, expected_options)
+          .and_return(spy('Vault::Secret'))
+
+        Vault::Rails.encrypt('path', 'key', 'plaintext', Vault::Rails.client, true)
+      end
+    end
+
+    context 'when convergent encryption is disabled' do
+      before do
+        allow(Vault::Rails).to receive(:enabled?).and_return(true)
+      end
+
+      it 'sends the correct paramaters to vault client' do
+        expected_route = 'path/encrypt/key'
+        expected_options = { plaintext: Base64.strict_encode64('plaintext') }
+
+        expect(Vault::Rails.client.logical).to receive(:write)
+          .with(expected_route, expected_options)
+          .and_return(spy('Vault::Secret'))
+
+        Vault::Rails.encrypt('path', 'key', 'plaintext', Vault::Rails.client, false)
+      end
+    end
+  end
+
+  describe '.decrypt' do
+    context 'when convergent encryption is enabled' do
+      before do
+        allow(Vault::Rails).to receive(:enabled?).and_return(true)
+        allow(Vault::Rails).to receive(:convergent_encryption_context).and_return('a' * 16)
+      end
+
+      it 'sends the correct paramaters to vault client' do
+        expected_route = 'path/decrypt/key'
+        expected_options = {
+          ciphertext: 'ciphertext',
+          context: Base64.strict_encode64(Vault::Rails.convergent_encryption_context)
+        }
+
+        expect(Vault::Rails.client.logical).to receive(:write)
+          .with(expected_route, expected_options)
+          .and_return(spy('Vault::Secret'))
+
+        Vault::Rails.decrypt('path', 'key', 'ciphertext', Vault::Rails.client, true)
+      end
+    end
+
+    context 'when convergent encryption is disabled' do
+      before do
+        allow(Vault::Rails).to receive(:enabled?).and_return(true)
+      end
+
+      it 'sends the correct paramaters to vault client' do
+        expected_route = 'path/decrypt/key'
+        expected_options = { ciphertext: 'ciphertext' }
+
+        expect(Vault::Rails.client.logical).to receive(:write)
+          .with(expected_route, expected_options)
+          .and_return(spy('Vault::Secret'))
+
+        Vault::Rails.decrypt('path', 'key', 'ciphertext', Vault::Rails.client, false)
+      end
     end
   end
 end

--- a/vault.gemspec
+++ b/vault.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency "rails", [">= 4.1", "< 5.1"]
-  s.add_dependency "vault", "~> 0.5"
+  s.add_dependency "vault", "~> 0.7"
 
   s.add_development_dependency "appraisal", "~> 2.1"
   s.add_development_dependency "bundler"


### PR DESCRIPTION
What does this PR do?
--------------------
* Adds support for convergent encryption

Where should the reviewer start?
-------------------------------
* `lib/vault/rails.rb`
* `lib/vault/encrypted_model.rb`

Any background context you want to provide?
------------------------------------------
* Vault supports convergent encryption since v0.6.1, but this gem
does not take advantage of this functionality.

/cc @popovm @bliof please review